### PR TITLE
Fix index path for WordPress

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,4 +14,4 @@
 define( 'WP_USE_THEMES', true );
 
 /** Loads the WordPress Environment and Template */
-require __DIR__ . '/wp-blog-header.php';
+require __DIR__ . '/public_html/wp-blog-header.php';


### PR DESCRIPTION
## Summary
- update the root `index.php` so it loads WordPress from `public_html`

## Testing
- `npm test` *(fails: could not find package.json)*
- `php -l index.php` *(fails: command not found)*