### PR TITLE
Sanitize wp-config and add deployment README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Website
+
+This repository contains a WordPress site.
+
+## Deployment
+
+1. Copy the contents of this repository to your server.
+2. Configure the WordPress `wp-config.php` file with your database credentials. A sample config is provided in `wp-config-sample.php`.
+   - `DB_NAME` – database name
+   - `DB_USER` – database user
+   - `DB_PASSWORD` – database password
+   - `DB_HOST` – database host, usually `localhost`
+3. Make sure the server meets WordPress requirements (PHP, web server, etc.).
+4. Run any database migrations or import data as needed.
+
+Environment variables can be used to set the credentials during deployment.

--- a/public_html/wp-config.php
+++ b/public_html/wp-config.php
@@ -3,7 +3,7 @@
  * The base configuration for WordPress
  *
  * The wp-config.php creation script uses this file during the installation.
- * You don't have to use the web site, you can copy this file to "wp-config.php"
+ * You don't have to use the website, you can copy this file to "wp-config.php"
  * and fill in the values.
  *
  * This file contains the following configurations:
@@ -13,7 +13,7 @@
  * * Database table prefix
  * * ABSPATH
  *
- * @link https://wordpress.org/documentation/article/editing-wp-config-php/
+ * @link https://developer.wordpress.org/advanced-administration/wordpress/wp-config/
  *
  * @package WordPress
  */
@@ -64,10 +64,32 @@ define( 'NONCE_SALT',       'put your unique phrase here' );
  *
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
+ *
+ * At the installation time, database tables are created with the specified prefix.
+ * Changing this value after WordPress is installed will make your site think
+ * it has not been installed.
+ *
+ * @link https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#table-prefix
  */
 $table_prefix = 'wp_';
 
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/
+ */
+define( 'WP_DEBUG', false );
+
 /* Add any custom values between this line and the "stop editing" line. */
+
+
 
 /* That's all, stop editing! Happy publishing. */
 


### PR DESCRIPTION
## Summary
- replace `public_html/wp-config.php` with the stock sample config
- add `README.md` with basic deployment notes

## Testing
- `npm test` *(fails: Could not read package.json)*