### PR TITLE
Fix WordPress include path

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,4 +14,5 @@
 define( 'WP_USE_THEMES', true );
 
 /** Loads the WordPress Environment and Template */
-require __DIR__ . '/wp-blog-header.php';
+require __DIR__ . '/public_html/wp-blog-header.php';
+


### PR DESCRIPTION
## Summary
- load `wp-blog-header.php` from the `public_html` directory

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*
- `pytest` *(fails: command not found)*