### PR TITLE
Add missing WordPress entry file

### DIFF
--- a/public_html/wp-blog-header.php
+++ b/public_html/wp-blog-header.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Loads the WordPress environment and template.
+ *
+ * Placeholder for WordPress entry point.
+ */
+
+require __DIR__ . '/wp-load.php';
+wp();
+require_once ABSPATH . WPINC . '/template-loader.php';
+


### PR DESCRIPTION
## Summary
- unpacked `public_html.zip`
- added `public_html/wp-blog-header.php` so that `index.php` has an entry point

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: command not found)*